### PR TITLE
pdfcat: Refactoring and new version check

### DIFF
--- a/bin/pdfcat
+++ b/bin/pdfcat
@@ -1,82 +1,87 @@
 #!/bin/bash
 
-## ----------------------------------------------------------------------------
-## A quick hack to replace pdfunite as it destroys too much of the original's
-## meta data.
-## ----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# A quick hack to replace pdfunite as it destroys too much of the original's
+# meta data.
+# ------------------------------------------------------------------------------
 
-## ----------------------------------------------------------------------------
-## Author:        Urs Roesch <github@bun.ch>
-## License:       MIT
-## Requires:      bash, pdftk >= 2.0
-## ----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# Author:        Urs Roesch <github@bun.ch>
+# License:       MIT
+# Requires:      bash, pdftk >= 2.0
+# ------------------------------------------------------------------------------
 
-## ----------------------------------------------------------------------------
-## Globals
-## ----------------------------------------------------------------------------
-PDFCAT_VERSION=0.1
-PRODUCER="pdfcat ${PDFCAT_VERSION}"
-SCRIPT=${0##*/}
-ARGUMENTS=$#
-REQUIRE_PDFTK=2
+# ------------------------------------------------------------------------------
+# Globals
+# ------------------------------------------------------------------------------
+declare -r PDFCAT_VERSION=0.1
+declare -r PRODUCER="pdfcat ${PDFCAT_VERSION}"
+declare -r PDFCAT_SCRIPT=${0##*/}
+declare -r ARGUMENTS=$#
+declare -r REQUIRE_PDFTK=2
 
-## ----------------------------------------------------------------------------
-## Functions
-## ----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# Functions
+# ------------------------------------------------------------------------------
 
-check_compatibility() {
+function pdftk_major() {
+  pdftk --version | \
+    awk '/^pdftk/ { print int(gensub("[^0-9.]", "", "g", $0)); exit }'
+}
+
+# ------------------------------------------------------------------------------
+
+function pdfcat_check_compatibility() {
   if ! which pdftk &>/dev/null; then
     echo "Required binary 'pdftk' was not found on this system" 1&>2
     exit 127
   else
-    pdftk_major=$(pdftk --version | awk '/^pdftk/ { print int($2) }')
-    if [[ ${pdftk_major} -lt ${REQUIRE_PDFTK} ]]; then
+    if [[ $(pdftk_major) -lt ${REQUIRE_PDFTK} ]]; then
       echo "Pdftk version ${REQUIRE_PDFTK}  or higher is required!" 1&>2
       exit 128
     fi
   fi
 }
 
-## ----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
-pdfcat_usage() {
+function pdfcat_usage() {
   local exit_code=$1; shift;
   echo "  Usage:"
-  echo "    ${SCRIPT} <pdf> <pdf> [..]"
+  echo "    ${PDFCAT_SCRIPT} <pdf> <pdf> [..]"
   echo ""
   exit ${exit_code}
 }
 
-## ----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
-fetch_meta() {
+function pdfcat_fetch_meta() {
   local file="$1"; shift;
   pdftk "${file}" dump_data_utf8 output - | grep ^Info
 }
 
-## ----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
-concat_pdf() {
+function pdfcat_concat_pdf() {
   [[ $# -eq 0 ]] && return
-  local meta=$( fetch_meta "$1" )
-  pdftk "$@" cat output - | write_meta "${meta}" 2>/dev/null
+  local meta=$( pdfcat_fetch_meta "$1" )
+  pdftk "$@" cat output - | pdfcat_write_meta "${meta}" 2>/dev/null
 }
 
-## ----------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 
-write_meta() {
+function pdfcat_write_meta() {
   local meta="$1"; shift;
   pdftk - update_info_utf8 <( echo "${meta}" ) output -
 }
 
-## ----------------------------------------------------------------------------
-## Main
-## ----------------------------------------------------------------------------
-
-check_compatibility
+# ------------------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------------------
+pdfcat_check_compatibility
 
 if [[ $0 == ${BASH_SOURCE} && ${ARGUMENTS} -lt 2 ]]; then
   pdfcat_usage 1;
 fi
 
-concat_pdf "$@"
+pdfcat_concat_pdf "$@"


### PR DESCRIPTION
Summary:
  * Add new version check for the pdftk-java
    version in newer Ubuntu releases.
  * Prefix most functions with `pdfcat_`
    to prevent naming collisions when
    sourced.