### PR TITLE
Workflow: Add bash compatibility testing

### DIFF
--- a/.github/workflows/bash-compatibility.yml
+++ b/.github/workflows/bash-compatibility.yml
@@ -1,0 +1,57 @@
+# -----------------------------------------------------------------------------
+# Verify bash compatibility
+# Author: Urs Roesch https://github.com/uroesch
+# Version: 0.1.0
+# -----------------------------------------------------------------------------
+name: bash-compatibility
+
+on:
+  push:
+    branches:
+    - workflow/*
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  bash-compatibility:
+    timeout-minutes: 15
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu-latest
+        bash:
+        # not yet compatible older bash versions
+        #- '3.0'
+        #- '3.1'
+        #- '3.2'
+        #- '4.0'
+        #- '4.1'
+        - '4.2'
+        - '4.3'
+        - '4.4'
+        - '5.0'
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        lfs: true
+
+    - name: Loop test
+      shell: bash
+      run: |
+        function install-dependencies() {
+          apk add curl poppler-utils imagemagick file openjdk11-jre-headless tesseract-ocr grep &&
+          curl -sJLO 'https://gitlab.com/pdftk-java/pdftk/-/jobs/812582458/artifacts/raw/build/libs/pdftk-all.jar?inline=false' &&
+          mv pdftk-all.jar /usr/lib/ &&
+          echo -e "#!/usr/bin/env bash\njava -jar /usr/lib/pdftk-all.jar \"\$@\"" > /usr/bin/pdftk &&
+          chmod 755 /usr/bin/pdftk
+        }
+        docker run \
+          --tty \
+          --volume $(pwd):/pdftools \
+          bash:${{ matrix.bash }} \
+          bash -c "$(declare -f install-dependencies); install-dependencies && /pdftools/test/test-pdftools"

--- a/test/test-pdftools
+++ b/test/test-pdftools
@@ -167,12 +167,14 @@ function test::pdfmeta() {
 
 function test::verify_pdfmeta() {
   test::is_pdf ${BASE_DIR}/pdfmeta.pdf
-  pdfinfo ${BASE_DIR}/pdfmeta.pdf | grep -q -E "Creator:.*pdfmeta-$$" 
+  # for some yet unknown reason `grep -q` croaks on alpine
+  # hence the redirect to /dev/null
+  pdfinfo ${BASE_DIR}/pdfmeta.pdf | grep -E "Creator:.*pdfmeta-$$" &>/dev/null
 }
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
-parse_options "${@}"
+parse_options "$@"
 test::setup
 test::download_pdf
 test::pdf_to_images


### PR DESCRIPTION
Summary:
  * Currently only with bash 4.2 and higher.
  * Small changes for alpine linux to the file
    `test-pdftools`.