### PR TITLE
Add Bash 5.1.x to tests

### DIFF
--- a/.github/workflows/bash-compatibility.yml
+++ b/.github/workflows/bash-compatibility.yml
@@ -33,6 +33,7 @@ jobs:
         - '4.3'
         - '4.4'
         - '5.0'
+        - '5.1'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/create-docs.yml
+++ b/.github/workflows/create-docs.yml
@@ -22,7 +22,6 @@ jobs:
         os:
         - ubuntu-20.04
         - ubuntu-18.04
-        - ubuntu-16.04
 
     steps:
     - name: Install asciidoctor 


### PR DESCRIPTION
Summary:
  * Remove Ubuntu 16.04 from the create docs workflow
    as one gem requires 2.4 or better.
  * Add the bash version check for the 5.1 release.