### PR TITLE
img2pdf: Bugfix throw error on unknown option

### DIFF
--- a/bin/img2pdf
+++ b/bin/img2pdf
@@ -21,7 +21,7 @@ set -o pipefail
 # Globals
 # ------------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare -r VERSION=0.2.4
+declare -r VERSION=0.2.5
 declare -r AUTHOR="Urs Roesch <github@bun.ch>"
 declare -r LICENSE="MIT"
 declare    IMAGE_COMPRESSION=${PDF_IMAGE:-jpeg}
@@ -123,11 +123,12 @@ function parse_options() {
   fi
   while (( $# > 0 )); do
     case $1 in
-    -h|--help)    usage 0;;
-    -d|--delete)  DELETE_IMAGES=true;;
-    -r|--rotate)  shift; IMAGE_ROTATE=$1;;
-    -o|--output)  shift; OUTPUT=$1; PDF_PREFIX="$$-${RANDOM}-";;
-    -V|--version) version;;
+    -h|--help)    usage 0 ;;
+    -d|--delete)  DELETE_IMAGES=true ;;
+    -r|--rotate)  shift; IMAGE_ROTATE=$1 ;;
+    -o|--output)  shift; OUTPUT=$1; PDF_PREFIX="$$-${RANDOM}-" ;;
+    -V|--version) version ;;
+    -*)           usage 1 ;;
     *)            IMAGES+=( "$1" );;
     esac
     shift


### PR DESCRIPTION
Summary:
  * when encountering a argument starting with
    a minus '-' an option is assumed. If the
    letter is unknown usage is displayed.