### PR TITLE
Test: Migrate ocrpdf tests to bats

### DIFF
--- a/bin/ocrpdf
+++ b/bin/ocrpdf
@@ -24,7 +24,7 @@ trap cleanup EXIT
 # Globals
 # ------------------------------------------------------------------------------
 declare -r SCRIPT=${0##*/}
-declare -r VERSION=0.4.0
+declare -r VERSION=0.4.1
 declare -r AUTHOR="Urs Roesch <github@bun.ch>"
 declare -r LICENSE="MIT"
 declare -- QUIET=
@@ -105,12 +105,12 @@ function usage() {
 
   Options:
     -h | --help         This message
-    -q | --quiet        Don't send display processed file names
-    -V | --version      Print version information and exit
     -l | --lang <lang>  Set the OCR languages to use.
                         For multiple languages concatenate with a '+'
                         E.g eng+deu for English and German
                         Default: ${OCR_LANG}
+    -q | --quiet        Don't send display processed file names
+    -V | --version      Print version information and exit
 
   Description:
     Runs PDFs through OCR and saves the output as a text searchable PDF

--- a/tests/img2pdf.bats
+++ b/tests/img2pdf.bats
@@ -30,30 +30,24 @@ load includes
 
 @test "img2pdf: Create pdf from png" {
   ::pdf-to-images png
-  output_pdf=${TEMP_DIR}/img2pdf-from-png.pdf
-  img2pdf \
-    --output ${output_pdf} \
-    $(find ${TEMP_DIR} -type f -name "*png")
-  ::is-pdf ${output_pdf}
+  pdf=${TEMP_DIR}/img2pdf-from-png.pdf
+  ::img2pdf "${pdf}" png
+  ::is-pdf "${pdf}"
   ::cleanup-tempdir
 }
 
 @test "img2pdf: Create pdf from tiff" {
   ::pdf-to-images tiff
-  output_pdf=${TEMP_DIR}/img2pdf-from-tiff.pdf
-  img2pdf \
-    --output ${output_pdf} \
-    $(find ${TEMP_DIR} -type f -name "*tif")
-  ::is-pdf ${output_pdf}
+  pdf=${TEMP_DIR}/img2pdf-from-tiff.pdf
+  ::img2pdf "${pdf}" tif
+  ::is-pdf "${pdf}"
   ::cleanup-tempdir
 }
 
 @test "img2pdf: Create pdf from jpeg" {
   ::pdf-to-images jpeg
-  output_pdf=${TEMP_DIR}/img2pdf-from-jpeg.pdf
-  img2pdf \
-    --output ${output_pdf} \
-    $(find ${TEMP_DIR} -type f -name "*jpg")
-  ::is-pdf ${output_pdf}
+  pdf=${TEMP_DIR}/img2pdf-from-jpeg.pdf
+  ::img2pdf "${pdf}" jpg
+  ::is-pdf "${pdf}"
   ::cleanup-tempdir
 }

--- a/tests/includes.bash
+++ b/tests/includes.bash
@@ -5,7 +5,7 @@
 # -----------------------------------------------------------------------------
 export PATH=${BATS_TEST_DIRNAME}/../bin:${PATH}
 export IMG2PDF_VERSION="v0.2.6"
-export OCRPDF_VERSION="v0.4.0"
+export OCRPDF_VERSION="v0.4.1"
 export PDF2PDFA_VERSION="v0.1.2"
 export PDFMETA_VERSION="v0.1.5"
 export PDFRESIZE_VERSION="v0.0.5"
@@ -47,4 +47,21 @@ function ::pdf-to-images() {
    -${format} \
    ${FILES_DIR}/${SAMPLE_PDF} \
    ${TEMP_DIR}/sample-image
+}
+
+function ::pdf-to-text() {
+  local pdf=${1}; shift;
+  local pattern=${1}; shift;
+  local occurrence=${1}; shift;
+  pdftotext "${pdf}"
+  count=$(grep -c "${pattern}" ${pdf%%.*}.txt 2>/dev/null)
+  (( count == occurrence ))
+}
+
+function ::img2pdf() {
+  local output=${1}; shift;
+  local source=${1}; shift;
+  img2pdf \
+    --output ${output} \
+    $(find ${TEMP_DIR} -type f -name "*.${source}")
 }

--- a/tests/ocrpdf.bats
+++ b/tests/ocrpdf.bats
@@ -5,16 +5,16 @@ load includes
 @test "ocrpdf: Common option --help" {
   output=$(ocrpdf --help 2>&1)
   [[ ${output} =~ ' --help ' ]]
-  [[ ${output} =~ ' --quiet ' ]]
   [[ ${output} =~ ' --lang ' ]]
+  [[ ${output} =~ ' --quiet ' ]]
   [[ ${output} =~ ' --version ' ]]
 }
 
 @test "ocrpdf: Common option -h" {
   output=$(ocrpdf -h 2>&1)
   [[ ${output} =~ ' -h ' ]]
-  [[ ${output} =~ ' -q ' ]]
   [[ ${output} =~ ' -l ' ]]
+  [[ ${output} =~ ' -q ' ]]
   [[ ${output} =~ ' -V ' ]]
 }
 
@@ -24,4 +24,34 @@ load includes
 
 @test "ocrpdf: Common option -V" {
   ocrpdf -V | grep -w ${OCRPDF_VERSION}
+}
+
+@test "ocrpdf: OCR pdf with png base" {
+  ::pdf-to-images png
+  pdf=${TEMP_DIR}/ocrpdf-png.pdf
+  ::img2pdf "${pdf}" png
+  ocrpdf -q "${pdf}"
+  ::is-pdf "${pdf}"
+  ::pdf-to-text "${pdf}" "Lorem ipsum" 10
+  ::cleanup-tempdir
+}
+
+@test "ocrpdf: OCR pdf with tiff base" {
+  ::pdf-to-images tiff
+  pdf=${TEMP_DIR}/ocrpdf-tiff.pdf
+  ::img2pdf "${pdf}" tif
+  ocrpdf -q "${pdf}"
+  ::is-pdf "${pdf}"
+  ::pdf-to-text "${pdf}" "Lorem ipsum" 10
+  ::cleanup-tempdir
+}
+
+@test "ocrpdf: OCR pdf with jpeg base" {
+  ::pdf-to-images jpeg
+  pdf=${TEMP_DIR}/ocrpdf-jpeg.pdf
+  ::img2pdf "${pdf}" jpg
+  ocrpdf -q "${pdf}"
+  ::is-pdf "${pdf}"
+  ::pdf-to-text "${pdf}" "Lorem ipsum" 10
+  ::cleanup-tempdir
 }


### PR DESCRIPTION
- Move tests from old frame work to bats.
- Add new test for png and tiff images not just jpegs.
- Reorder the switches and options alphabetically.
- Create new functions in include.bash.