### PR TITLE
Workflow: Add tests for Debian 12

### DIFF
--- a/.github/workflows/bash-compatibility.yml
+++ b/.github/workflows/bash-compatibility.yml
@@ -51,7 +51,11 @@ jobs:
           openjdk11-jre-headless \
           poppler-utils \
           sane-utils \
-          tesseract-ocr
+          tesseract-ocr \
+          tesseract-ocr-data-deu \
+          tesseract-ocr-data-eng \
+          tesseract-ocr-data-fra \
+          tesseract-ocr-data-ita
 
     - name: Install pdftk
       shell: bash

--- a/.github/workflows/create-docs.yml
+++ b/.github/workflows/create-docs.yml
@@ -26,6 +26,7 @@ jobs:
           - ubuntu:22.04
           - ubuntu:20.04
           - ubuntu:18.04
+          - debian:12
           - debian:11
           - debian:10
     env:

--- a/.github/workflows/os-compatibilty.yml
+++ b/.github/workflows/os-compatibilty.yml
@@ -30,6 +30,7 @@ jobs:
           - { name: ubuntu, release: 20.04 }
           - { name: ubuntu, release: 18.04 }
         # - { name: ubuntu, release: 16.04 }
+          - { name: debian, release: 12 }
           - { name: debian, release: 11 }
           - { name: debian, release: 10 }
         

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,11 @@ test-bash:
 			openjdk11-jre-headless \
 			poppler-utils \
 			sane-utils \
-			tesseract-ocr; \
+			tesseract-ocr \
+			tesseract-ocr-data-deu \
+			tesseract-ocr-data-eng \
+			tesseract-ocr-data-fra \
+			tesseract-ocr-data-ita; \
 			curl -sJLO 'https://gitlab.com/pdftk-java/pdftk/-/jobs/812582458/artifacts/raw/build/libs/pdftk-all.jar?inline=false' && \
 			mv pdftk-all.jar /usr/lib/ && \
 			echo -e "#!/usr/bin/env bash\njava -jar /usr/lib/pdftk-all.jar \"\$$@\"" > /usr/bin/pdftk && \
@@ -127,6 +131,7 @@ test-bash:
 	};
 	for version in $${VERSIONS[@]}; do
 		@echo "Test bash version $${version}"
+		docker pull bash:$${version}; \
 		docker run \
 			--rm \
 			--tty \


### PR DESCRIPTION
- Add debian 12 as test os for os-compatibility and create-docs.
- Fix the bash compatibility check by adding tesseract languages.
- Add a pull to get the latest version of the bash container in the test-bash make target.